### PR TITLE
Update to Cecilapp/GitHub-Pages-deploy@v3

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -26,7 +26,7 @@ jobs:
   
 # Need to first create an empty gh-pages branch
 # see https://pkgdown.r-lib.org/reference/deploy_site_github.html
-# and also add secrets for a GH_PAT and EMAIL to the repository
+# and also add a secrets for an EMAIL to the repository
 # gh-action from Cecilapp/GitHub-Pages-deploy
   checkout-and-deploy:
    runs-on: ubuntu-latest
@@ -42,10 +42,10 @@ jobs:
          # Destination path
          path: _book # optional
      - name: Deploy to GitHub Pages
-       uses: Cecilapp/GitHub-Pages-deploy@master
+       uses: Cecilapp/GitHub-Pages-deploy@v3
        env:
-          EMAIL: ${{ secrets.EMAIL }}               # must be a verified email
-          GH_TOKEN: ${{ secrets.GH_PAT }} # https://github.com/settings/tokens
-          BUILD_DIR: _book/                     # "_site/" by default
-    
- 
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+       with:
+         email:  ${{ secrets.EMAIL }} # must be a verified email
+         build_dir: _book             # "_site/" by default
+         


### PR DESCRIPTION
Hi,

The previous version of `deploy_bookdowm.yml` used `Cecilapp/GitHub-Pages-deploy@master`, but the action changed with this latest version, `Cecilapp/GitHub-Pages-deploy@v3`. The action now uses GITHUB_TOKEN and input parameters, see:

https://github.com/Cecilapp/GitHub-Pages-deploy/blob/12981df74c347334d5b2f178d116c00092bf34f8/README.md

As a result, the previous version of `deploy_bookdown.yml` currently fails with the error `cp: can't stat '_site/*': No such file or directory` because environmental variable `BUILD_DIR` must now be provided as input parameter `build_dir`.

Another possible solution is to specify the previous version of the action with `Cecilapp/GitHub-Pages-deploy@v2`, which still exclusively uses environment variables.

Best,

Stephan